### PR TITLE
feat(core): add hmac module for header or query verification

### DIFF
--- a/packages/core/src/hmac/hmac.constants.ts
+++ b/packages/core/src/hmac/hmac.constants.ts
@@ -1,0 +1,1 @@
+export const SHOPIFY_HMAC_KEY = 'SHOPIFY_HMAC_KEY';

--- a/packages/core/src/hmac/hmac.decorators.spec.ts
+++ b/packages/core/src/hmac/hmac.decorators.spec.ts
@@ -1,0 +1,28 @@
+import { Reflector } from '@nestjs/core';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { SHOPIFY_HMAC_KEY } from './hmac.constants';
+import { ShopifyHmac } from './hmac.decorators';
+import { ShopifyHmacType } from './hmac.enums';
+import { ShopifyHmacGuard } from './hmac.guard';
+
+describe('ShopifyHmac', () => {
+  const reflector = new Reflector();
+
+  describe.each([ShopifyHmacType.Header, ShopifyHmacType.Query])(
+    'with %s hmac type',
+    (hmacType) => {
+      @ShopifyHmac(hmacType)
+      class TargetClass {}
+
+      it('should add hmac type to target class', () => {
+        expect(reflector.get(SHOPIFY_HMAC_KEY, TargetClass)).toEqual(hmacType);
+      });
+
+      it('should add hmac guard to target class', () => {
+        expect(reflector.get(GUARDS_METADATA, TargetClass)).toContain(
+          ShopifyHmacGuard
+        );
+      });
+    }
+  );
+});

--- a/packages/core/src/hmac/hmac.decorators.ts
+++ b/packages/core/src/hmac/hmac.decorators.ts
@@ -1,0 +1,10 @@
+import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+import { SHOPIFY_HMAC_KEY } from './hmac.constants';
+import { ShopifyHmacType } from './hmac.enums';
+import { ShopifyHmacGuard } from './hmac.guard';
+
+export const ShopifyHmac = (hmacType: ShopifyHmacType) =>
+  applyDecorators(
+    SetMetadata(SHOPIFY_HMAC_KEY, hmacType),
+    UseGuards(ShopifyHmacGuard)
+  );

--- a/packages/core/src/hmac/hmac.enums.ts
+++ b/packages/core/src/hmac/hmac.enums.ts
@@ -1,0 +1,4 @@
+export enum ShopifyHmacType {
+  Header = 'header',
+  Query = 'query',
+}

--- a/packages/core/src/hmac/hmac.guard.spec.ts
+++ b/packages/core/src/hmac/hmac.guard.spec.ts
@@ -1,0 +1,164 @@
+import {
+  BadRequestException,
+  ExecutionContext,
+  InternalServerErrorException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import Shopify, { AuthQuery, ShopifyHeader } from '@shopify/shopify-api';
+import { ContextInterface } from '@shopify/shopify-api/dist/context';
+import { ShopifyHmacType } from './hmac.enums';
+import { ShopifyHmacGuard } from './hmac.guard';
+import { ShopifyHmacModule } from './hmac.module';
+
+describe('ShopifyHmacGuard', () => {
+  let guard: ShopifyHmacGuard;
+  let reflector: jest.Mocked<Reflector>;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [ShopifyHmacModule],
+    })
+      .overrideProvider(Reflector)
+      .useValue({
+        getAllAndOverride: jest.fn(),
+      })
+      .compile();
+
+    Shopify.Context = {
+      API_SECRET_KEY: 'foobar',
+    } as ContextInterface;
+
+    guard = module.get(ShopifyHmacGuard);
+    reflector = module.get(Reflector);
+  });
+
+  describe('without hmac type', () => {
+    beforeEach(() => {
+      reflector.getAllAndOverride.mockReturnValueOnce(undefined);
+    });
+
+    it('should return true', () => {
+      const ctx = createExecutionContext();
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+  });
+
+  describe('with query param', () => {
+    beforeEach(() => {
+      reflector.getAllAndOverride.mockReturnValueOnce(ShopifyHmacType.Query);
+    });
+
+    it('should throw bad request if hmac missing', () => {
+      const ctx = createExecutionContext({
+        query: {
+          hmac: undefined,
+          host: 'https://test.myshopify.io',
+          shop: 'test.myshopify.io',
+          state: '12345678',
+          timestamp: '1662473266',
+        },
+      });
+
+      expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+
+    it('should throw bad request if hmac is wrong', () => {
+      const ctx = createExecutionContext({
+        query: {
+          hmac: 'wrong',
+          host: 'https://test.myshopify.io',
+          shop: 'test.myshopify.io',
+          state: '12345678',
+          timestamp: '1662473266',
+        },
+      });
+
+      expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+
+    it('should return true if hmac is correct', () => {
+      const ctx = createExecutionContext({
+        query: {
+          code: 'foo',
+          hmac: '58e42546fa36deb542ab297d2c5e133412470f39ada4b3c6dc974b9f54b04184',
+          host: 'https://test.myshopify.io',
+          shop: 'test.myshopify.io',
+          state: '12345678',
+          timestamp: '1662473266',
+        },
+      });
+
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+  });
+
+  describe('with header', () => {
+    beforeEach(() => {
+      reflector.getAllAndOverride.mockReturnValueOnce(ShopifyHmacType.Header);
+    });
+
+    it('should throw bad request if hmac missing', () => {
+      const ctx = createExecutionContext({ headers: {} });
+
+      expect(() => guard.canActivate(ctx)).toThrow(BadRequestException);
+    });
+
+    it('should throw internal server error if raw body empty', () => {
+      const ctx = createExecutionContext({
+        headers: {
+          [ShopifyHeader.Hmac]: 'wrong',
+        },
+      });
+
+      expect(() => guard.canActivate(ctx)).toThrow(
+        InternalServerErrorException
+      );
+    });
+
+    it('should throw unauthorized if hmac is wrong', () => {
+      const body = '{"amount":0.0}';
+      const ctx = createExecutionContext({
+        headers: {
+          [ShopifyHeader.Hmac]: 'wrong',
+        },
+        rawBody: Buffer.from(body),
+      });
+
+      expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+
+    it('should return true if hmac is correct', () => {
+      const body = '{"amount":0.0}';
+      const ctx = createExecutionContext({
+        headers: {
+          [ShopifyHeader.Hmac]: 'KXP0rjCPtfpj6NdrhOoXZUMaMV8qS9DQ25fY8rnjkxc=',
+        },
+        rawBody: Buffer.from(body),
+      });
+
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+  });
+});
+
+interface RequestLike {
+  rawBody?: Buffer;
+  headers?: Record<string, string>;
+  query?: Partial<AuthQuery>;
+}
+
+function createExecutionContext(req?: RequestLike): ExecutionContext {
+  const context = {
+    switchToHttp: jest.fn(),
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+  };
+
+  context.switchToHttp.mockImplementation(() => ({
+    getRequest: jest.fn().mockReturnValue(req),
+  }));
+
+  return context as unknown as ExecutionContext;
+}

--- a/packages/core/src/hmac/hmac.guard.ts
+++ b/packages/core/src/hmac/hmac.guard.ts
@@ -1,0 +1,108 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  InternalServerErrorException,
+  RawBodyRequest,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import Shopify, { AuthQuery, ShopifyHeader } from '@shopify/shopify-api';
+import validateHmac from '@shopify/shopify-api/dist/utils/hmac-validator';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { IncomingMessage } from 'http';
+import { SHOPIFY_HMAC_KEY } from './hmac.constants';
+import { ShopifyHmacType } from './hmac.enums';
+
+@Injectable()
+export class ShopifyHmacGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const hmacType = this.getShopifyHmacTypeFromContext(context);
+    if (!hmacType) {
+      return true;
+    }
+
+    const req: RawBodyRequest<IncomingMessage> = context
+      .switchToHttp()
+      .getRequest();
+
+    switch (hmacType) {
+      case ShopifyHmacType.Query:
+        return this.validateHmacQuery(req);
+      case ShopifyHmacType.Header:
+        return this.validateHmacHeader(req);
+    }
+  }
+
+  private validateHmacHeader(req: RawBodyRequest<IncomingMessage>) {
+    const expectedHmac = this.getHmacFromHeaders(req);
+
+    if (!req.rawBody) {
+      throw new InternalServerErrorException(
+        `Missing raw body in request. Ensure that 'rawBody' option is set when initializing Nest application.`
+      );
+    }
+
+    const generatedHash = createHmac('sha256', Shopify.Context.API_SECRET_KEY)
+      .update(req.rawBody)
+      .digest('base64');
+    const generatedHashBuffer = Buffer.from(generatedHash);
+    const hmacBuffer = Buffer.from(expectedHmac);
+
+    if (generatedHashBuffer.length !== hmacBuffer.length) {
+      throw new UnauthorizedException('Webhook HMAC validation failed.');
+    }
+
+    if (!timingSafeEqual(generatedHashBuffer, hmacBuffer)) {
+      throw new UnauthorizedException('Webhook HMAC validation failed.');
+    }
+
+    return true;
+  }
+
+  private validateHmacQuery(req: IncomingMessage) {
+    const query = (req as unknown as { query: AuthQuery }).query;
+
+    try {
+      if (!validateHmac(query)) {
+        throw new UnauthorizedException('Invalid HMAC provided');
+      }
+
+      return true;
+    } catch (err) {
+      throw new UnauthorizedException(err);
+    }
+  }
+
+  private getHmacFromHeaders(req: IncomingMessage): string {
+    const hmacHeader =
+      req.headers[ShopifyHeader.Hmac] ||
+      req.headers[ShopifyHeader.Hmac.toLowerCase()];
+
+    if (!hmacHeader) {
+      throw new BadRequestException(
+        `Missing required HTTP header: ${ShopifyHeader.Hmac}`
+      );
+    }
+
+    if (typeof hmacHeader !== 'string') {
+      throw new BadRequestException(
+        `Malformed '${ShopifyHeader.Hmac}' provided: ${hmacHeader}`
+      );
+    }
+
+    return hmacHeader;
+  }
+
+  private getShopifyHmacTypeFromContext(
+    ctx: ExecutionContext
+  ): ShopifyHmacType | undefined {
+    return this.reflector.getAllAndOverride<ShopifyHmacType | undefined>(
+      SHOPIFY_HMAC_KEY,
+      [ctx.getHandler(), ctx.getClass()]
+    );
+  }
+}

--- a/packages/core/src/hmac/hmac.module.ts
+++ b/packages/core/src/hmac/hmac.module.ts
@@ -1,0 +1,8 @@
+import { Global, Module } from '@nestjs/common';
+import { ShopifyHmacGuard } from './hmac.guard';
+
+@Global()
+@Module({
+  providers: [ShopifyHmacGuard],
+})
+export class ShopifyHmacModule {}

--- a/packages/core/src/hmac/index.ts
+++ b/packages/core/src/hmac/index.ts
@@ -1,0 +1,4 @@
+export * from './hmac.decorators';
+export * from './hmac.enums';
+export * from './hmac.guard';
+export * from './hmac.module';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
 export * from './core.constants';
 export * from './core.interfaces';
 export * from './core.module';
+
+export * from './hmac';

--- a/packages/webhooks/src/webhooks.controller.ts
+++ b/packages/webhooks/src/webhooks.controller.ts
@@ -8,11 +8,10 @@ import {
   Post,
   RawBodyRequest,
   Req,
-  UnauthorizedException,
 } from '@nestjs/common';
-import type { IncomingMessage } from 'http';
+import { ShopifyHmac, ShopifyHmacType } from '@nestjs-shopify/core';
 import Shopify, { ShopifyHeader } from '@shopify/shopify-api';
-import { createHmac, timingSafeEqual } from 'crypto';
+import type { IncomingMessage } from 'http';
 import { SHOPIFY_WEBHOOKS_DEFAULT_PATH } from './webhooks.constants';
 
 @Controller(SHOPIFY_WEBHOOKS_DEFAULT_PATH)
@@ -21,6 +20,7 @@ export class ShopifyWebhooksController {
 
   @Post()
   @HttpCode(200)
+  @ShopifyHmac(ShopifyHmacType.Header)
   async handle(@Req() req: RawBodyRequest<IncomingMessage>) {
     const { rawBody } = req;
     if (!rawBody) {
@@ -28,10 +28,8 @@ export class ShopifyWebhooksController {
         'Enable `rawBody` option when creating Nest application.'
       );
     }
-    const { domain, hmac, topic } = this.getHeaders(req);
 
-    this.validateHmac(rawBody, hmac as string);
-
+    const { domain, topic } = this.getHeaders(req);
     const graphqlTopic = (topic as string).toUpperCase().replace(/\//g, '_');
     const webhookEntry = Shopify.Webhooks.Registry.getHandler(graphqlTopic);
 
@@ -50,32 +48,11 @@ export class ShopifyWebhooksController {
     }
   }
 
-  private validateHmac(rawBody: Buffer, hmac: string) {
-    const generatedHash = createHmac('sha256', Shopify.Context.API_SECRET_KEY)
-      .update(rawBody)
-      .digest('base64');
-
-    const generatedHashBuffer = Buffer.from(generatedHash);
-    const hmacBuffer = Buffer.from(hmac);
-
-    if (generatedHashBuffer.length !== hmacBuffer.length) {
-      throw new UnauthorizedException('Webhook HMAC validation failed.');
-    }
-
-    if (!timingSafeEqual(generatedHashBuffer, hmacBuffer)) {
-      throw new UnauthorizedException('Webhook HMAC validation failed.');
-    }
-  }
-
   private getHeaders(req: IncomingMessage) {
-    let hmac: string | string[] | undefined;
     let topic: string | string[] | undefined;
     let domain: string | string[] | undefined;
     Object.entries(req.headers).map(([header, value]) => {
       switch (header.toLowerCase()) {
-        case ShopifyHeader.Hmac.toLowerCase():
-          hmac = value;
-          break;
         case ShopifyHeader.Topic.toLowerCase():
           topic = value;
           break;
@@ -86,9 +63,6 @@ export class ShopifyWebhooksController {
     });
 
     const missingHeaders = [];
-    if (!hmac) {
-      missingHeaders.push(ShopifyHeader.Hmac);
-    }
     if (!topic) {
       missingHeaders.push(ShopifyHeader.Topic);
     }
@@ -105,7 +79,6 @@ export class ShopifyWebhooksController {
     }
 
     return {
-      hmac,
       topic,
       domain,
     };


### PR DESCRIPTION
Use `@ShopifyHmac` decorator. Make sure to import the `ShopifyHmacModule` in your application.