### PR TITLE
fix(): use new shopify-session-storage package

### DIFF
--- a/.changeset/forty-needles-mix.md
+++ b/.changeset/forty-needles-mix.md
@@ -1,0 +1,10 @@
+---
+'@nestjs-shopify/core': major
+---
+
+Use new `@shopify/shopify-app-session-storage` package as the session storage engine.
+
+See https://github.com/Shopify/shopify-app-js/tree/main/packages for a list of session storage engines,
+or provide your own by extending the provided `SessionStorage` interface in `@nestjs-shopify/core`.
+
+Run `npm install @shopify/shopify-app-session-storage` because it's a required peer dependency.

--- a/integration/src/shopify-initializer/session-storage/memory.session-storage.ts
+++ b/integration/src/shopify-initializer/session-storage/memory.session-storage.ts
@@ -6,7 +6,35 @@ import { SessionStorage } from '../../../../packages/core/src';
 export class MemorySessionStorage implements SessionStorage {
   private readonly sessions = new Map<string, Session>();
 
-  async getSessionById(id: string): Promise<Session | undefined> {
+  async storeSession(session: Session): Promise<boolean> {
+    this.sessions.set(session.id, session);
+    return true;
+  }
+
+  async loadSession(id: string): Promise<Session | undefined> {
     return this.sessions.get(id);
+  }
+
+  async deleteSession(id: string): Promise<boolean> {
+    this.sessions.delete(id);
+    return true;
+  }
+
+  async deleteSessions(ids: string[]): Promise<boolean> {
+    for (const id in ids) {
+      await this.deleteSession(id);
+    }
+    return true;
+  }
+
+  async findSessionsByShop(shop: string): Promise<Session[]> {
+    const sessions = [];
+    for (const session of this.sessions.values()) {
+      if (session.shop === shop) {
+        sessions.push(session);
+      }
+    }
+
+    return sessions;
   }
 }

--- a/integration/test/auth-e2e/hybrid.spec.ts
+++ b/integration/test/auth-e2e/hybrid.spec.ts
@@ -24,7 +24,7 @@ describe('Hybrid Authz (e2e)', () => {
     })
       .overrideProvider(MemorySessionStorage)
       .useValue({
-        getSessionById: jest.fn(),
+        loadSession: jest.fn(),
       })
       .compile();
 
@@ -66,7 +66,7 @@ describe('Hybrid Authz (e2e)', () => {
     let token: string;
 
     beforeEach(async () => {
-      sessionStorage.getSessionById.mockResolvedValueOnce(session);
+      sessionStorage.loadSession.mockResolvedValueOnce(session);
 
       token = jwt.sign(jwtPayload, shopifyApi.config.apiSecretKey, {
         algorithm: 'HS256',

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@nrwl/linter": "14.3.5",
         "@nrwl/workspace": "14.3.5",
         "@shopify/shopify-api": "6.0.0",
+        "@shopify/shopify-app-session-storage": "^1.0.0",
         "@types/jest": "27.4.1",
         "@types/jsonwebtoken": "^8.5.9",
         "@types/node": "16.11.7",
@@ -2652,6 +2653,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@shopify/shopify-app-session-storage": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@shopify/shopify-app-session-storage/-/shopify-app-session-storage-1.0.0.tgz",
+      "integrity": "sha512-5jW5fQBL23jOiCoMoTMPlt1CGF2Es0NMU23ZvK25BrGgTkwYHj/rjyD/YPMRGvwxqDJY07HEalPIueLdzoVFXw==",
+      "dependencies": {
+        "@shopify/shopify-api": "^6.0.0",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -10429,12 +10439,12 @@
     },
     "packages/auth": {
       "name": "@nestjs-shopify/auth",
-      "version": "0.0.15",
+      "version": "1.0.0",
       "peerDependencies": {
         "@nestjs-shopify/core": "*",
         "@nestjs/common": "*",
         "@nestjs/core": "*",
-        "@shopify/shopify-api": "*"
+        "@shopify/shopify-api": "^6.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs-shopify/core": {
@@ -10453,11 +10463,12 @@
     },
     "packages/core": {
       "name": "@nestjs-shopify/core",
-      "version": "0.0.15",
+      "version": "1.0.0",
       "peerDependencies": {
         "@nestjs/common": "*",
         "@nestjs/core": "*",
-        "@shopify/shopify-api": "*"
+        "@shopify/shopify-api": "^6.0.0",
+        "@shopify/shopify-app-session-storage": "^1.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs/common": {
@@ -10473,15 +10484,19 @@
     },
     "packages/graphql": {
       "name": "@nestjs-shopify/graphql",
-      "version": "0.0.15",
+      "version": "1.0.0",
       "peerDependencies": {
         "@nestjs-shopify/auth": "*",
+        "@nestjs-shopify/core": "*",
         "@nestjs/common": "*",
         "@nestjs/core": "*",
-        "@shopify/shopify-api": "*"
+        "@shopify/shopify-api": "^6.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs-shopify/auth": {
+          "optional": false
+        },
+        "@nestjs-shopify/core": {
           "optional": false
         },
         "@nestjs/common": {
@@ -10497,11 +10512,11 @@
     },
     "packages/webhooks": {
       "name": "@nestjs-shopify/webhooks",
-      "version": "0.0.15",
+      "version": "1.0.0",
       "peerDependencies": {
         "@nestjs/common": "*",
         "@nestjs/core": "*",
-        "@shopify/shopify-api": "*"
+        "@shopify/shopify-api": "^6.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs/common": {
@@ -12319,6 +12334,15 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "@shopify/shopify-app-session-storage": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@shopify/shopify-app-session-storage/-/shopify-app-session-storage-1.0.0.tgz",
+      "integrity": "sha512-5jW5fQBL23jOiCoMoTMPlt1CGF2Es0NMU23ZvK25BrGgTkwYHj/rjyD/YPMRGvwxqDJY07HEalPIueLdzoVFXw==",
+      "requires": {
+        "@shopify/shopify-api": "^6.0.0",
+        "tslib": "^2.4.0"
       }
     },
     "@sinonjs/commons": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nrwl/linter": "14.3.5",
     "@nrwl/workspace": "14.3.5",
     "@shopify/shopify-api": "6.0.0",
+    "@shopify/shopify-app-session-storage": "^1.0.0",
     "@types/jest": "27.4.1",
     "@types/jsonwebtoken": "^8.5.9",
     "@types/node": "16.11.7",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,7 +6,7 @@
     "@nestjs/common": "*",
     "@nestjs/core": "*",
     "@nestjs-shopify/core": "*",
-    "@shopify/shopify-api": "*"
+    "@shopify/shopify-api": "^6.0.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/common": {

--- a/packages/auth/src/auth-base.controller.ts
+++ b/packages/auth/src/auth-base.controller.ts
@@ -1,4 +1,8 @@
-import { Controller, Get, Query, Req, Res } from '@nestjs/common';
+import {
+  SessionStorage,
+  SHOPIFY_API_SESSION_STORAGE,
+} from '@nestjs-shopify/core';
+import { Controller, Get, Inject, Query, Req, Res } from '@nestjs/common';
 import { ApplicationConfig } from '@nestjs/core';
 import { Shopify } from '@shopify/shopify-api';
 import type { IncomingMessage, ServerResponse } from 'http';
@@ -11,7 +15,9 @@ export abstract class ShopifyAuthBaseController {
     protected readonly shopifyApi: Shopify,
     protected readonly accessMode: AccessMode,
     protected readonly options: ShopifyAuthModuleOptions,
-    protected readonly appConfig: ApplicationConfig
+    protected readonly appConfig: ApplicationConfig,
+    @Inject(SHOPIFY_API_SESSION_STORAGE)
+    protected readonly sessionStorage: SessionStorage
   ) {}
 
   @Get('auth')
@@ -53,6 +59,8 @@ export abstract class ShopifyAuthBaseController {
     });
 
     if (session) {
+      await this.sessionStorage.storeSession(session);
+
       if (this.options.afterAuthHandler) {
         await this.options.afterAuthHandler.afterAuth(req, res, session);
         return;

--- a/packages/auth/src/auth.guard.ts
+++ b/packages/auth/src/auth.guard.ts
@@ -87,7 +87,7 @@ export class ShopifyAuthGuard implements CanActivate {
         throw new InvalidSession('No session found');
       }
 
-      session = await this.sessionStorage.getSessionById(sessionId);
+      session = await this.sessionStorage.loadSession(sessionId);
     } catch (err) {
       this.logger.error(err);
       session = undefined;

--- a/packages/auth/src/offline-auth/offline-auth.controller.ts
+++ b/packages/auth/src/offline-auth/offline-auth.controller.ts
@@ -3,8 +3,12 @@ import { ApplicationConfig } from '@nestjs/core';
 import { AccessMode, ShopifyAuthModuleOptions } from '../auth.interfaces';
 import { ShopifyAuthBaseController } from '../auth-base.controller';
 import { getOptionsToken } from '../auth.constants';
-import { SHOPIFY_API_CONTEXT } from '@nestjs-shopify/core';
+import {
+  SHOPIFY_API_CONTEXT,
+  SHOPIFY_API_SESSION_STORAGE,
+} from '@nestjs-shopify/core';
 import { Shopify } from '@shopify/shopify-api';
+import { SessionStorage } from '@shopify/shopify-app-session-storage';
 
 @Controller('shopify/offline')
 export class ShopifyAuthOfflineController extends ShopifyAuthBaseController {
@@ -12,8 +16,10 @@ export class ShopifyAuthOfflineController extends ShopifyAuthBaseController {
     @Inject(SHOPIFY_API_CONTEXT) override readonly shopifyApi: Shopify,
     @Inject(getOptionsToken(AccessMode.Offline))
     override readonly options: ShopifyAuthModuleOptions,
-    override readonly appConfig: ApplicationConfig
+    override readonly appConfig: ApplicationConfig,
+    @Inject(SHOPIFY_API_SESSION_STORAGE)
+    override readonly sessionStorage: SessionStorage
   ) {
-    super(shopifyApi, AccessMode.Offline, options, appConfig);
+    super(shopifyApi, AccessMode.Offline, options, appConfig, sessionStorage);
   }
 }

--- a/packages/auth/src/online-auth/online-auth.controller.ts
+++ b/packages/auth/src/online-auth/online-auth.controller.ts
@@ -3,7 +3,11 @@ import { ApplicationConfig } from '@nestjs/core';
 import { AccessMode, ShopifyAuthModuleOptions } from '../auth.interfaces';
 import { ShopifyAuthBaseController } from '../auth-base.controller';
 import { getOptionsToken } from '../auth.constants';
-import { SHOPIFY_API_CONTEXT } from '@nestjs-shopify/core';
+import {
+  SessionStorage,
+  SHOPIFY_API_CONTEXT,
+  SHOPIFY_API_SESSION_STORAGE,
+} from '@nestjs-shopify/core';
 import { Shopify } from '@shopify/shopify-api';
 
 @Controller('shopify/online')
@@ -12,8 +16,10 @@ export class ShopifyAuthOnlineController extends ShopifyAuthBaseController {
     @Inject(SHOPIFY_API_CONTEXT) override readonly shopifyApi: Shopify,
     @Inject(getOptionsToken(AccessMode.Online))
     override readonly options: ShopifyAuthModuleOptions,
-    override readonly appConfig: ApplicationConfig
+    override readonly appConfig: ApplicationConfig,
+    @Inject(SHOPIFY_API_SESSION_STORAGE)
+    override readonly sessionStorage: SessionStorage
   ) {
-    super(shopifyApi, AccessMode.Online, options, appConfig);
+    super(shopifyApi, AccessMode.Online, options, appConfig, sessionStorage);
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,8 @@
   "peerDependencies": {
     "@nestjs/common": "*",
     "@nestjs/core": "*",
-    "@shopify/shopify-api": "*"
+    "@shopify/shopify-api": "^6.0.0",
+    "@shopify/shopify-app-session-storage": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/common": {

--- a/packages/core/src/core.interfaces.ts
+++ b/packages/core/src/core.interfaces.ts
@@ -1,11 +1,13 @@
-import { ConfigInterface, Session } from '@shopify/shopify-api';
+import { ConfigParams, ShopifyRestResources } from '@shopify/shopify-api';
+import { SessionStorage as ShopifySessionStorage } from '@shopify/shopify-app-session-storage';
 import { ASYNC_OPTIONS_TYPE } from './core.module-builder';
 
-export interface SessionStorage {
-  getSessionById(id: string): Promise<Session | undefined>;
-}
+export type SessionStorage = ShopifySessionStorage;
 
-export interface ShopifyCoreOptions extends ConfigInterface {
+export interface ShopifyCoreOptions<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends ShopifyRestResources = any
+> extends ConfigParams<T> {
   sessionStorage: SessionStorage;
 }
 

--- a/packages/core/src/core.module.ts
+++ b/packages/core/src/core.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { ConfigInterface, shopifyApi } from '@shopify/shopify-api';
+import { shopifyApi } from '@shopify/shopify-api';
 import {
   SHOPIFY_API_CONTEXT,
   SHOPIFY_API_SESSION_STORAGE,
@@ -14,7 +14,7 @@ import {
   providers: [
     {
       provide: SHOPIFY_API_CONTEXT,
-      useFactory: (options: ConfigInterface) => shopifyApi(options),
+      useFactory: (options: ShopifyCoreOptions) => shopifyApi(options),
       inject: [SHOPIFY_CORE_OPTIONS],
     },
     {

--- a/packages/core/tests/helpers/mock-session-storage.ts
+++ b/packages/core/tests/helpers/mock-session-storage.ts
@@ -1,6 +1,6 @@
 import { MockedObject } from 'ts-jest';
 import { SessionStorage } from '../../src/core.interfaces';
 
-export const mockSessionStorage: MockedObject<SessionStorage> = {
-  getSessionById: jest.fn(),
-};
+export const mockSessionStorage = {
+  loadSession: jest.fn(),
+} as unknown as MockedObject<SessionStorage>;

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -6,10 +6,14 @@
     "@nestjs/common": "*",
     "@nestjs/core": "*",
     "@nestjs-shopify/auth": "*",
-    "@shopify/shopify-api": "*"
+    "@nestjs-shopify/core": "*",
+    "@shopify/shopify-api": "^6.0.0"
   },
   "peerDependenciesMeta": {
     "@nestjs-shopify/auth": {
+      "optional": false
+    },
+    "@nestjs-shopify/core": {
       "optional": false
     },
     "@nestjs/common": {

--- a/packages/graphql/tests/feature/graphql-proxy.spec.ts
+++ b/packages/graphql/tests/feature/graphql-proxy.spec.ts
@@ -55,7 +55,7 @@ describe('GraphQL proxy', () => {
       jest
         .spyOn(shopifyApi.session, 'getCurrentId')
         .mockResolvedValueOnce('token-id');
-      mockSessionStorage.getSessionById.mockResolvedValueOnce(session);
+      mockSessionStorage.loadSession.mockResolvedValueOnce(session);
 
       graphqlProxySpy.mockResolvedValueOnce({
         headers: { 'content-type': 'application/json' },

--- a/packages/graphql/tests/helpers/mock-session-storage.ts
+++ b/packages/graphql/tests/helpers/mock-session-storage.ts
@@ -1,6 +1,6 @@
 import { SessionStorage } from '@nestjs-shopify/core';
 import { MockedObject } from 'ts-jest';
 
-export const mockSessionStorage: MockedObject<SessionStorage> = {
-  getSessionById: jest.fn().mockResolvedValue(undefined),
-};
+export const mockSessionStorage = {
+  loadSession: jest.fn(),
+} as unknown as MockedObject<SessionStorage>;

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -5,7 +5,7 @@
   "peerDependencies": {
     "@nestjs/common": "*",
     "@nestjs/core": "*",
-    "@shopify/shopify-api": "*"
+    "@shopify/shopify-api": "^6.0.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/common": {

--- a/packages/webhooks/tests/helpers/mock-session-storage.ts
+++ b/packages/webhooks/tests/helpers/mock-session-storage.ts
@@ -1,6 +1,6 @@
 import { SessionStorage } from '@nestjs-shopify/core';
 import { MockedObject } from 'ts-jest';
 
-export const mockSessionStorage: MockedObject<SessionStorage> = {
-  getSessionById: jest.fn(),
-};
+export const mockSessionStorage = {
+  loadSession: jest.fn(),
+} as unknown as MockedObject<SessionStorage>;


### PR DESCRIPTION
Fixes the usage of session storages.

They were removed from `@shopify/shopify-api`. They now are living in `@shopify/shopify-app-session-storage`.