### PR TITLE
fix(auth): add jsonwebtoken dependency

### DIFF
--- a/.changeset/spicy-apes-smash.md
+++ b/.changeset/spicy-apes-smash.md
@@ -1,0 +1,5 @@
+---
+'@nestjs-shopify/auth': patch
+---
+
+Add missing `jsonwebtoken` dependency

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -2,6 +2,9 @@
   "name": "@nestjs-shopify/auth",
   "version": "2.0.0",
   "type": "commonjs",
+  "dependencies": {
+    "jsonwebtoken": "^8.0.0"
+  },
   "peerDependencies": {
     "@nestjs/common": "*",
     "@nestjs/core": "*",


### PR DESCRIPTION
Fixes #82 

This adds the missing `jsonwebtoken` dependency to `@nestjs-shopify/auth`.