### PR TITLE
tests(webhooks): Add unit tests for `ShopifyWebhooksService` and `ShopifyWebhooksMetadataAccessor` providers

### DIFF
--- a/packages/webhooks/src/webhooks.service.ts
+++ b/packages/webhooks/src/webhooks.service.ts
@@ -11,13 +11,13 @@ export class ShopifyWebhooksService {
   ) {}
 
   async registerWebhooks(session: Session) {
-    const response = await this.shopifyApi.webhooks.register({
+    const responsesByTopic = await this.shopifyApi.webhooks.register({
       session,
     });
 
-    Object.keys(response).forEach((topic: string) => {
-      response[topic].forEach((result) => {
-        if (result.success) {
+    Object.keys(responsesByTopic).forEach((topic: string) => {
+      responsesByTopic[topic].forEach((response) => {
+        if (response.success) {
           this.logger.log(`Registered webhook ${topic} successfully.`);
         } else {
           this.logger.warn(

--- a/packages/webhooks/tests/unit/webhooks-metadata.accessor.spec.ts
+++ b/packages/webhooks/tests/unit/webhooks-metadata.accessor.spec.ts
@@ -1,0 +1,75 @@
+import '@shopify/shopify-api/adapters/node';
+import { Test } from '@nestjs/testing';
+import { WebhookHandler } from '../../src/webhooks.decorators';
+import { ShopifyWebhooksMetadataAccessor } from '../../src/webhooks-metadata.accessor';
+import { ShopifyWebhooksModule } from '../../src/webhooks.module';
+import { MockShopifyCoreModule } from '../helpers/mock-shopify-core-module';
+import { Scope } from '@nestjs/common';
+
+@WebhookHandler('PRODUCTS_CREATE')
+class Handler1 {}
+
+@WebhookHandler({ topic: 'PRODUCTS_UPDATE', scope: Scope.TRANSIENT })
+class Handler2 {}
+
+class NonHandler3 {}
+
+describe('ShopifyWebhooksMetadataAccessor', () => {
+  let accessor: ShopifyWebhooksMetadataAccessor;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        MockShopifyCoreModule,
+        ShopifyWebhooksModule.forRoot({ path: 'metadata' }),
+      ],
+    }).compile();
+
+    accessor = module.get(ShopifyWebhooksMetadataAccessor);
+  });
+
+  describe('.getShopifyWebhooksHandlerMetadata', () => {
+    it('should return an object for `Handler1`', () => {
+      const metadata = accessor.getShopifyWebhooksHandlerMetadata(Handler1);
+
+      expect(metadata).toEqual({
+        topic: 'PRODUCTS_CREATE',
+      });
+    });
+
+    it('should return an object with scope for `Handler2', () => {
+      const metadata = accessor.getShopifyWebhooksHandlerMetadata(Handler2);
+
+      expect(metadata).toEqual({
+        topic: 'PRODUCTS_UPDATE',
+        scope: Scope.TRANSIENT,
+      });
+    });
+
+    it('should return undefined for `NonHandler3` class', () => {
+      const metadata = accessor.getShopifyWebhooksHandlerMetadata(NonHandler3);
+
+      expect(metadata).toBeUndefined();
+    });
+  });
+
+  describe('.isShopifyWebhookHandler', () => {
+    it('should return true for `Handler1`', () => {
+      const isHandler = accessor.isShopifyWebhookHandler(Handler1);
+
+      expect(isHandler).toBe(true);
+    });
+
+    it('should return true for `Handler2', () => {
+      const isHandler = accessor.isShopifyWebhookHandler(Handler2);
+
+      expect(isHandler).toBe(true);
+    });
+
+    it('should return false for `NonHandler3`', () => {
+      const isHandler = accessor.isShopifyWebhookHandler(NonHandler3);
+
+      expect(isHandler).toBe(false);
+    });
+  });
+});

--- a/packages/webhooks/tests/unit/webhooks.service.spec.ts
+++ b/packages/webhooks/tests/unit/webhooks.service.spec.ts
@@ -1,0 +1,85 @@
+import '@shopify/shopify-api/adapters/node';
+import { SHOPIFY_API_CONTEXT } from '@nestjs-shopify/core';
+import { Test } from '@nestjs/testing';
+import { DeliveryMethod, Session, Shopify } from '@shopify/shopify-api';
+import { ShopifyWebhooksModule } from '../../src/webhooks.module';
+import { ShopifyWebhooksService } from '../../src/webhooks.service';
+import { MockShopifyCoreModule } from '../helpers/mock-shopify-core-module';
+import { Logger } from '@nestjs/common';
+
+describe('ShopifyWebhooksService', () => {
+  let service: ShopifyWebhooksService;
+  let shopifyApi: Shopify;
+  let shopifyWebhooksRegisterSpy: jest.SpyInstance;
+
+  const mockLogger = {
+    log: jest.fn(),
+    warn: jest.fn(),
+  } as unknown as Logger;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        MockShopifyCoreModule,
+        ShopifyWebhooksModule.forRoot({ path: 'testing' }),
+      ],
+    }).compile();
+
+    service = module.get(ShopifyWebhooksService);
+    shopifyApi = module.get(SHOPIFY_API_CONTEXT);
+
+    (service as unknown as { logger: Logger }).logger = mockLogger;
+
+    shopifyWebhooksRegisterSpy = jest
+      .spyOn(shopifyApi.webhooks, 'register')
+      .mockResolvedValue({
+        'products/create': [
+          {
+            deliveryMethod: DeliveryMethod.Http,
+            result: 'Forced error in tests',
+            success: false,
+          },
+        ],
+        'products/update': [
+          {
+            deliveryMethod: DeliveryMethod.EventBridge,
+            result: { data: { webhookSubscriptionCreate: {} } },
+            success: true,
+          },
+        ],
+      });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('.registerWebhooks', () => {
+    const session = {
+      accessToken: 'fake-access-token',
+      shop: 'nestjs-shopify.myshopify.com',
+    } as Session;
+
+    it('should call `shopifyApi.webhooks.register` with provided session', async () => {
+      await service.registerWebhooks(session);
+
+      expect(shopifyWebhooksRegisterSpy).toHaveBeenCalledWith({ session });
+    });
+
+    it('should log failures', async () => {
+      await service.registerWebhooks(session);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to register webhook products/create: Forced error in tests'
+      );
+    });
+
+    it('should log successes', async () => {
+      await service.registerWebhooks(session);
+
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        'Registered webhook products/update successfully.'
+      );
+    });
+  });
+});


### PR DESCRIPTION
These tests also brought up a small issue in the error handler for webhooks. We were always printing `undefined` for the error message.