### PR TITLE
feat: update redirect path

### DIFF
--- a/.changeset/tame-ducks-eat.md
+++ b/.changeset/tame-ducks-eat.md
@@ -1,5 +1,5 @@
 ---
-'@nestjs-shopify/auth': major
+'@nestjs-shopify/auth': minor
 ---
 
 Respect `shopifyApi.hostScheme` and `shopifyApi.hostname` in OAuth redirect, see #166

--- a/.changeset/tame-ducks-eat.md
+++ b/.changeset/tame-ducks-eat.md
@@ -1,0 +1,5 @@
+---
+'@nestjs-shopify/auth': major
+---
+
+Respect `shopifyApi.hostScheme` and `shopifyApi.hostname` in OAuth redirect, see #166

--- a/packages/auth/src/auth.filter.ts
+++ b/packages/auth/src/auth.filter.ts
@@ -1,5 +1,7 @@
+import { InjectShopify } from '@nestjs-shopify/core';
 import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
 import { ApplicationConfig, ModuleRef } from '@nestjs/core';
+import { Shopify } from '@shopify/shopify-api';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { getOptionsToken } from './auth.constants';
 import { ShopifyAuthException } from './auth.errors';
@@ -12,9 +14,9 @@ export class ShopifyAuthExceptionFilter
 {
   constructor(
     private readonly moduleRef: ModuleRef,
-    private readonly appConfig: ApplicationConfig
+    private readonly appConfig: ApplicationConfig,
     @InjectShopify()
-    private readonly shopifyApi: Shopify 
+    private readonly shopifyApi: Shopify
   ) {}
 
   async catch(exception: ShopifyAuthException, host: ArgumentsHost) {
@@ -24,7 +26,7 @@ export class ShopifyAuthExceptionFilter
     const req = context.getRequest<IncomingMessage>();
     const res = context.getResponse<ServerResponse>();
     res.statusCode = exception.getStatus();
-    
+
     const hostScheme = this.shopifyApi.config.hostScheme ?? 'https';
     const hostName = this.shopifyApi.config.hostName ?? req.headers.host;
     const domain = `${hostScheme}://${hostName}`;

--- a/packages/auth/src/auth.filter.ts
+++ b/packages/auth/src/auth.filter.ts
@@ -13,6 +13,8 @@ export class ShopifyAuthExceptionFilter
   constructor(
     private readonly moduleRef: ModuleRef,
     private readonly appConfig: ApplicationConfig
+    @InjectShopify()
+    private readonly shopifyApi: Shopify 
   ) {}
 
   async catch(exception: ShopifyAuthException, host: ArgumentsHost) {
@@ -22,8 +24,10 @@ export class ShopifyAuthExceptionFilter
     const req = context.getRequest<IncomingMessage>();
     const res = context.getResponse<ServerResponse>();
     res.statusCode = exception.getStatus();
-
-    const domain = `https://${req.headers.host}`;
+    
+    const hostScheme = this.shopifyApi.config.hostScheme ?? 'https';
+    const hostName = this.shopifyApi.config.hostName ?? req.headers.host;
+    const domain = `${hostScheme}://${hostName}`;
     const redirectPath = this.buildRedirectPath(exception.shop, options);
     const authUrl = new URL(redirectPath, domain).toString();
 


### PR DESCRIPTION
Hello, here are some changes about `redirectPath`, hope you can accept them.

Use configuration instead of hard coding, if shopify config has `hostScheme` and `hostName`, we should use them.

This change can solve a problem I have currently, I use `http://localhost` as the auth url for shopify app in development environment. But the code fixed `https`, causing redirection errors.