### PR TITLE
refactor(auth): simplify the controller path override provider

### DIFF
--- a/.changeset/perfect-owls-jump.md
+++ b/.changeset/perfect-owls-jump.md
@@ -1,0 +1,5 @@
+---
+'@nestjs-shopify/auth': patch
+---
+
+Refactored online and offline auth controller path override

--- a/packages/auth/src/auth.constants.ts
+++ b/packages/auth/src/auth.constants.ts
@@ -4,6 +4,3 @@ export const AUTH_MODE_KEY = 'shopify:authMode';
 
 export const getOptionsToken = (mode: AccessMode) =>
   `ShopifyAuthModuleOptions(${mode})`;
-
-export const getControllerHackToken = (mode: AccessMode) =>
-  `ShopifyAuthModuleControllerHack(${mode})`;

--- a/packages/auth/src/auth.module.ts
+++ b/packages/auth/src/auth.module.ts
@@ -1,5 +1,5 @@
 import { DynamicModule } from '@nestjs/common';
-import { getControllerHackToken, getOptionsToken } from './auth.constants';
+import { getOptionsToken } from './auth.constants';
 import {
   AccessMode,
   ShopifyAuthModuleAsyncOptions,
@@ -22,7 +22,6 @@ export class ShopifyAuthModule {
         },
         buildControllerHackForToken(
           getOptionsToken(AccessMode.Online),
-          getControllerHackToken(AccessMode.Online),
           ShopifyAuthOnlineController
         ),
       ],
@@ -41,7 +40,6 @@ export class ShopifyAuthModule {
         },
         buildControllerHackForToken(
           getOptionsToken(AccessMode.Offline),
-          getControllerHackToken(AccessMode.Offline),
           ShopifyAuthOfflineController
         ),
       ],
@@ -60,7 +58,6 @@ export class ShopifyAuthModule {
         ...buildProvidersForToken(options, getOptionsToken(AccessMode.Online)),
         buildControllerHackForToken(
           getOptionsToken(AccessMode.Online),
-          getControllerHackToken(AccessMode.Online),
           ShopifyAuthOnlineController
         ),
       ],
@@ -79,7 +76,6 @@ export class ShopifyAuthModule {
         ...buildProvidersForToken(options, getOptionsToken(AccessMode.Offline)),
         buildControllerHackForToken(
           getOptionsToken(AccessMode.Offline),
-          getControllerHackToken(AccessMode.Offline),
           ShopifyAuthOfflineController
         ),
       ],

--- a/packages/auth/src/utils/build-controller-hack-for-token.util.ts
+++ b/packages/auth/src/utils/build-controller-hack-for-token.util.ts
@@ -1,18 +1,20 @@
-import { Provider, Type } from '@nestjs/common';
-import { PATH_METADATA } from '@nestjs/common/constants';
+import { randomUUID } from 'crypto';
+import { Controller, Provider, Type } from '@nestjs/common';
 import { ShopifyAuthBaseController } from '../auth-base.controller';
 import { ShopifyAuthModuleOptions } from '../auth.interfaces';
 
+/**
+ * Used to dynamically override the auth controller's path
+ */
 export function buildControllerHackForToken(
   optionsToken: string,
-  hackToken: string,
   controller: Type<ShopifyAuthBaseController>
 ): Provider {
   return {
-    provide: hackToken,
+    provide: randomUUID(),
     useFactory: (options: ShopifyAuthModuleOptions) => {
       if (options.basePath) {
-        Reflect.defineMetadata(PATH_METADATA, options.basePath, controller);
+        Controller(options.basePath)(controller);
       }
     },
     inject: [optionsToken],


### PR DESCRIPTION
No need to directly call `Reflect.defineMetadata`. We can just call the `Controller` decorator as a function to achieve the same result.