### PR TITLE
fix(auth): remove constructor TS `override readonly` qualifiers

### DIFF
--- a/.changeset/sour-carrots-deliver.md
+++ b/.changeset/sour-carrots-deliver.md
@@ -1,0 +1,5 @@
+---
+'@nestjs-shopify/auth': patch
+---
+
+Remove `override readonly` keyword usage in online and offline auth controllers

--- a/packages/auth/src/offline-auth/offline-auth.controller.ts
+++ b/packages/auth/src/offline-auth/offline-auth.controller.ts
@@ -13,12 +13,11 @@ import { getOptionsToken } from '../auth.constants';
 @Controller('shopify/offline')
 export class ShopifyAuthOfflineController extends ShopifyAuthBaseController {
   constructor(
-    @InjectShopify() override readonly shopifyApi: Shopify,
+    @InjectShopify() shopifyApi: Shopify,
     @Inject(getOptionsToken(AccessMode.Offline))
-    override readonly options: ShopifyAuthModuleOptions,
-    override readonly appConfig: ApplicationConfig,
-    @InjectShopifySessionStorage()
-    override readonly sessionStorage: SessionStorage
+    options: ShopifyAuthModuleOptions,
+    @InjectShopifySessionStorage() sessionStorage: SessionStorage,
+    appConfig: ApplicationConfig
   ) {
     super(shopifyApi, AccessMode.Offline, options, appConfig, sessionStorage);
   }

--- a/packages/auth/src/online-auth/online-auth.controller.ts
+++ b/packages/auth/src/online-auth/online-auth.controller.ts
@@ -13,12 +13,11 @@ import { getOptionsToken } from '../auth.constants';
 @Controller('shopify/online')
 export class ShopifyAuthOnlineController extends ShopifyAuthBaseController {
   constructor(
-    @InjectShopify() override readonly shopifyApi: Shopify,
+    @InjectShopify() shopifyApi: Shopify,
     @Inject(getOptionsToken(AccessMode.Online))
-    override readonly options: ShopifyAuthModuleOptions,
-    override readonly appConfig: ApplicationConfig,
-    @InjectShopifySessionStorage()
-    override readonly sessionStorage: SessionStorage
+    options: ShopifyAuthModuleOptions,
+    @InjectShopifySessionStorage() sessionStorage: SessionStorage,
+    appConfig: ApplicationConfig
   ) {
     super(shopifyApi, AccessMode.Online, options, appConfig, sessionStorage);
   }


### PR DESCRIPTION
No need to use `override readonly` in these controllers. All we do is pass them directly to the super class.