### PR TITLE
feat(core): add csp middleware

### DIFF
--- a/.changeset/four-dragons-fly.md
+++ b/.changeset/four-dragons-fly.md
@@ -1,0 +1,5 @@
+---
+'@nestjs-shopify/core': minor
+---
+
+Add `ShopifyCspMiddleware` to assign CSP frame-ancestors. See [NestJS Docs](https://docs.nestjs.com/middleware#applying-middleware) on how to use this middleware in your app.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -75,10 +75,7 @@ import { MyRedisSessionStorage } from './my-redis-session-storage';
 @Module({
   imports: [
     ShopifyCoreModule.forRootAsync({
-      useFactory: async (
-        configService: ConfigService,
-        sessionStorage: MyRedisSessionStorage
-      ) => {
+      useFactory: async (configService: ConfigService, sessionStorage: MyRedisSessionStorage) => {
         return {
           apiKey: configService.get('SHOPIFY_API_KEY'),
           apiSecret: configService.get('SHOPIFY_API_SECRET'),
@@ -100,10 +97,7 @@ export class AppModule {}
 ```ts
 // my-redis-session-storage.ts
 import { Injectable } from '@nestjs/common';
-import {
-  SessionStorage,
-  SessionInterface,
-} from '@shopify/shopify-api/dist/auth/session';
+import { SessionStorage, SessionInterface } from '@shopify/shopify-api/dist/auth/session';
 
 @Injectable()
 export class MyRedisSessionStorage implements SessionStorage {
@@ -117,6 +111,35 @@ export class MyRedisSessionStorage implements SessionStorage {
 
   async deleteSession(id: string): Promise<boolean> {
     // ... implement your redis delete logic
+  }
+}
+```
+
+# CSP middleware
+
+The library provides a CSP middleware that you can use to protect your application from XSS attacks. The middleware is not applied by default. To make use of this middleware, add the following to your application root module:
+
+```ts
+// app.module.ts
+import { ShopifyCoreModule, ShopifyCspMiddleware } from '@nestjs-shopify/core';
+import { Module, NestModule } from '@nestjs/common';
+
+@Module({
+  imports: [
+    ShopifyCoreModule.forRoot({ ... }),
+    // ...
+  ],
+})
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    // Apply the middleware to all routes
+    consumer.apply(ShopifyCspMiddleware).forRoutes('*');
+
+    // Or apply the middleware to specific routes
+    consumer
+      .apply(ShopifyCspMiddleware)
+      .exclude('cats')
+      .forRoutes({ path: 'ab*cd', method: RequestMethod.ALL });
   }
 }
 ```

--- a/packages/core/src/csp/csp.middleware.ts
+++ b/packages/core/src/csp/csp.middleware.ts
@@ -1,0 +1,34 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { InjectShopify } from '../core.decorators';
+import { Shopify } from '@shopify/shopify-api';
+
+interface RequestLike {
+  query: Record<string, string>;
+}
+
+interface ResponseLike {
+  setHeader: (key: string, value: string) => void;
+}
+
+@Injectable()
+export class ShopifyCspMiddleware implements NestMiddleware {
+  constructor(@InjectShopify() private readonly shopifyApi: Shopify) {}
+
+  public use(req: RequestLike, res: ResponseLike, next: () => void) {
+    const { shop } = req.query;
+    const sanitizedShop = this.shopifyApi.utils.sanitizeShop(shop);
+
+    if (this.shopifyApi.config.isEmbeddedApp && sanitizedShop) {
+      res.setHeader(
+        'Content-Security-Policy',
+        `frame-ancestors https://${encodeURIComponent(
+          sanitizedShop
+        )} https://admin.shopify.com;`
+      );
+    } else {
+      res.setHeader('Content-Security-Policy', 'frame-ancestors none');
+    }
+
+    next();
+  }
+}

--- a/packages/core/src/csp/index.ts
+++ b/packages/core/src/csp/index.ts
@@ -1,0 +1,1 @@
+export * from './csp.middleware';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,4 +4,5 @@ export { SHOPIFY_CORE_OPTIONS } from './core.module-builder';
 export * from './core.interfaces';
 export * from './core.module';
 
+export * from './csp';
 export * from './hmac';

--- a/packages/core/tests/feature/csp.spec.ts
+++ b/packages/core/tests/feature/csp.spec.ts
@@ -1,0 +1,88 @@
+import '@shopify/shopify-api/adapters/node';
+import {
+  Controller,
+  Get,
+  INestApplication,
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { SHOPIFY_API_CONTEXT } from '../../src/core.constants';
+import { ShopifyCspMiddleware } from '../../src/csp/csp.middleware';
+import { MockShopifyCoreModule } from '../helpers/mock-shopify-core-module';
+import { Shopify } from '@shopify/shopify-api';
+
+@Controller()
+export class DummyController {
+  @Get()
+  public index() {
+    return 'Hello World!';
+  }
+}
+
+@Module({
+  controllers: [DummyController],
+})
+export class DummyModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(ShopifyCspMiddleware).forRoutes('*');
+  }
+}
+
+describe('ShopifyCspMiddleware', () => {
+  let app: INestApplication;
+  let shopifyApi: Shopify;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [MockShopifyCoreModule, DummyModule],
+    }).compile();
+
+    app = await module.createNestApplication().init();
+
+    shopifyApi = module.get<Shopify>(SHOPIFY_API_CONTEXT);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    jest.restoreAllMocks();
+  });
+
+  describe('when embedded app', () => {
+    beforeEach(() => {
+      shopifyApi.config.isEmbeddedApp = true;
+    });
+
+    it('should set CSP frame-ancestors when shop is provided', async () => {
+      await request(app.getHttpServer())
+        .get('/?shop=shop1.myshopify.com')
+        .expect(
+          'Content-Security-Policy',
+          'frame-ancestors https://shop1.myshopify.com https://admin.shopify.com;'
+        )
+        .expect(200);
+    });
+
+    it('should set CSP frame-ancestors to none when shop is not provided', async () => {
+      await request(app.getHttpServer())
+        .get('/')
+        .expect('Content-Security-Policy', 'frame-ancestors none')
+        .expect(200);
+    });
+  });
+
+  describe('when non-embedded app', () => {
+    beforeEach(() => {
+      shopifyApi.config.isEmbeddedApp = false;
+    });
+
+    it('should set CSP frame-ancestors to none', async () => {
+      await request(app.getHttpServer())
+        .get('/')
+        .expect('Content-Security-Policy', 'frame-ancestors none')
+        .expect(200);
+    });
+  });
+});


### PR DESCRIPTION
Related #193 

Adds a `ShopifyCspMiddleware` for developers to use in their app. They will need to apply this middleware themselves. `nestjs-shopify` cannot assume which routes need this CSP header. That's why it isn't applied automatically.