### PR TITLE
chore(deps): pin nestjs packages to supported range

### DIFF
--- a/.changeset/nice-carrots-hope.md
+++ b/.changeset/nice-carrots-hope.md
@@ -1,0 +1,8 @@
+---
+'@nestjs-shopify/webhooks': patch
+'@nestjs-shopify/graphql': patch
+'@nestjs-shopify/auth': patch
+'@nestjs-shopify/core': patch
+---
+
+Disallow @nestjs versions lower than `9.0.0`. Older versions will not work.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,8 +14,8 @@
     "jsonwebtoken": "^9.0.0"
   },
   "peerDependencies": {
-    "@nestjs/common": "*",
-    "@nestjs/core": "*",
+    "@nestjs/common": "^9.0.0 || ^10.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0",
     "@nestjs-shopify/core": "^3.0.0",
     "@shopify/shopify-api": "^7.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,8 +11,8 @@
     "url": "git+https://github.com/nestjs-shopify/nestjs-shopify.git"
   },
   "peerDependencies": {
-    "@nestjs/common": "*",
-    "@nestjs/core": "*",
+    "@nestjs/common": "^9.0.0 || ^10.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0",
     "@shopify/shopify-api": "^7.0.0",
     "@shopify/shopify-app-session-storage": "^1.1.2"
   },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -11,8 +11,8 @@
     "url": "git+https://github.com/nestjs-shopify/nestjs-shopify.git"
   },
   "peerDependencies": {
-    "@nestjs/common": "*",
-    "@nestjs/core": "*",
+    "@nestjs/common": "^9.0.0 || ^10.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0",
     "@nestjs-shopify/auth": "^4.0.0",
     "@nestjs-shopify/core": "^3.0.0",
     "@shopify/shopify-api": "^7.0.0"

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -11,8 +11,8 @@
     "url": "git+https://github.com/nestjs-shopify/nestjs-shopify.git"
   },
   "peerDependencies": {
-    "@nestjs/common": "*",
-    "@nestjs/core": "*",
+    "@nestjs/common": "^9.0.0 || ^10.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0",
     "@nestjs-shopify/core": "^3.0.0",
     "@shopify/shopify-api": "^7.0.0"
   },


### PR DESCRIPTION
We only support NestJS `v9.0.0` and `v10.0.0`.

Version 8 and lower not supported due to usages of `ConfigurableModuleBuilder`.