### PR TITLE
fix: stringify webhook registration error response

### DIFF
--- a/.changeset/real-drinks-exercise.md
+++ b/.changeset/real-drinks-exercise.md
@@ -1,0 +1,5 @@
+---
+'@nestjs-shopify/webhooks': patch
+---
+
+fix: stringify webhook registration error response

--- a/packages/webhooks/src/webhooks.service.ts
+++ b/packages/webhooks/src/webhooks.service.ts
@@ -19,7 +19,9 @@ export class ShopifyWebhooksService {
           this.logger.log(`Registered webhook ${topic} successfully.`);
         } else {
           this.logger.warn(
-            `Failed to register webhook ${topic}: ${response['result']}`
+            `Failed to register webhook ${topic}: ${JSON.stringify(
+              response['result'],
+            )}`,
           );
         }
       });

--- a/packages/webhooks/tests/unit/webhooks.service.spec.ts
+++ b/packages/webhooks/tests/unit/webhooks.service.spec.ts
@@ -72,7 +72,7 @@ describe('ShopifyWebhooksService', () => {
       await service.registerWebhooks(session);
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'Failed to register webhook products/create: Forced error in tests'
+        'Failed to register webhook products/create: "Forced error in tests"'
       );
     });
 


### PR DESCRIPTION
print the full response instead of just `[object Object]`