### PR TITLE
Fix: wrong interface for after auth handler

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -85,7 +85,7 @@ export class AuthHandlerModule {}
 ```ts
 // auth-handler/my-auth.handler.ts
 @Injectable()
-export class MyAuthHandler implements ShopifyAuthTokenExchangeAfterHandler {
+export class MyAuthHandler implements ShopifyTokenExchangeAuthAfterHandler {
   constructor(private readonly tokenExchangeService: ShopifyTokenExchangeService) {}
   async afterAuth({ session, sessionToken }: ShopifyAuthTokenExchangeAfterHandlerParams) {
     if (session.isOnline) {

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -87,7 +87,7 @@ export class AuthHandlerModule {}
 @Injectable()
 export class MyAuthHandler implements ShopifyTokenExchangeAuthAfterHandler {
   constructor(private readonly tokenExchangeService: ShopifyTokenExchangeService) {}
-  async afterAuth({ session, sessionToken }: ShopifyAuthTokenExchangeAfterHandlerParams) {
+  async afterAuth({ session, sessionToken }: ShopifyTokenExchangeAuthAfterHandlerParams) {
     if (session.isOnline) {
       try {
         const offlineSession = await this.tokenExchangeService.exchangeToken(sessionToken, session.shop, AccessMode.Offline);


### PR DESCRIPTION
The documented interface is wrong, it is exported as `ShopifyTokenExchangeAuthAfterHandler` from the package.
Same goes for `ShopifyTokenExchangeAuthAfterHandlerParams`