### PR TITLE
chore: bump peer dependencies for NestJS 11 support

### DIFF
--- a/.changeset/angry-birds-care.md
+++ b/.changeset/angry-birds-care.md
@@ -1,9 +1,9 @@
 ---
-'@nestjs-shopify/webhooks': major
-'@nestjs-shopify/express': major
-'@nestjs-shopify/graphql': major
-'@nestjs-shopify/auth': major
-'@nestjs-shopify/core': major
+'@nestjs-shopify/webhooks': patch
+'@nestjs-shopify/express': patch
+'@nestjs-shopify/graphql': patch
+'@nestjs-shopify/auth': patch
+'@nestjs-shopify/core': patch
 ---
 
 chore: bump peer dependencies for NestJS 11 support

--- a/.changeset/angry-birds-care.md
+++ b/.changeset/angry-birds-care.md
@@ -1,0 +1,9 @@
+---
+'@nestjs-shopify/webhooks': major
+'@nestjs-shopify/express': major
+'@nestjs-shopify/graphql': major
+'@nestjs-shopify/auth': major
+'@nestjs-shopify/core': major
+---
+
+chore: bump peer dependencies for NestJS 11 support

--- a/package-lock.json
+++ b/package-lock.json
@@ -7521,6 +7521,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "devOptional": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -14816,8 +14817,8 @@
       },
       "peerDependencies": {
         "@nestjs-shopify/core": "^5.0.0",
-        "@nestjs/common": "^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
         "@shopify/shopify-api": "^11.0.0"
       },
       "peerDependenciesMeta": {
@@ -14858,8 +14859,8 @@
       "name": "@nestjs-shopify/core",
       "version": "5.0.0",
       "peerDependencies": {
-        "@nestjs/common": "^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
         "@shopify/shopify-api": "^11.0.0",
         "@shopify/shopify-app-session-storage": "^3.0.0"
       },
@@ -14883,8 +14884,8 @@
       },
       "peerDependencies": {
         "@nestjs-shopify/core": "^5.0.0",
-        "@nestjs/common": "^9.0.0 || ^10.0.0",
-        "express": "^4.0.0"
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "express": "^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs-shopify/core": {
@@ -14927,8 +14928,8 @@
       "peerDependencies": {
         "@nestjs-shopify/auth": "^6.0.0",
         "@nestjs-shopify/core": "^5.0.0",
-        "@nestjs/common": "^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
         "@shopify/shopify-api": "^11.0.0"
       },
       "peerDependenciesMeta": {
@@ -14955,8 +14956,8 @@
       "peerDependencies": {
         "@nestjs-shopify/common": "^2.0.0",
         "@nestjs-shopify/core": "^5.0.0",
-        "@nestjs/common": "^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
         "@shopify/shopify-api": "^11.0.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "dependencies": {
     "@changesets/cli": "2.27.10",
     "@nx/devkit": "20.1.4",
+    "@nx/eslint": "20.1.4",
     "@nx/eslint-plugin": "20.1.4",
     "@nx/jest": "20.1.4",
     "@nx/js": "20.1.4",
-    "@nx/eslint": "20.1.4",
     "@nx/workspace": "20.1.4",
     "nx": "20.1.4",
     "reflect-metadata": "0.2.2",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,8 +14,8 @@
     "jsonwebtoken": "^9.0.0"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0 || ^10.0.0",
-    "@nestjs/core": "^9.0.0 || ^10.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@nestjs-shopify/core": "^5.0.0",
     "@shopify/shopify-api": "^11.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,8 +11,8 @@
     "url": "git+https://github.com/nestjs-shopify/nestjs-shopify.git"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0 || ^10.0.0",
-    "@nestjs/core": "^9.0.0 || ^10.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@shopify/shopify-api": "^11.0.0",
     "@shopify/shopify-app-session-storage": "^3.0.0"
   },

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -5,9 +5,9 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0 || ^10.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@nestjs-shopify/core": "^5.0.0",
-    "express": "^4.0.0"
+    "express": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/common": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -11,8 +11,8 @@
     "url": "git+https://github.com/nestjs-shopify/nestjs-shopify.git"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0 || ^10.0.0",
-    "@nestjs/core": "^9.0.0 || ^10.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@nestjs-shopify/auth": "^6.0.0",
     "@nestjs-shopify/core": "^5.0.0",
     "@shopify/shopify-api": "^11.0.0"

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -11,8 +11,8 @@
     "url": "git+https://github.com/nestjs-shopify/nestjs-shopify.git"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0 || ^10.0.0",
-    "@nestjs/core": "^9.0.0 || ^10.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@nestjs-shopify/common": "^2.0.0",
     "@nestjs-shopify/core": "^5.0.0",
     "@shopify/shopify-api": "^11.0.0"


### PR DESCRIPTION
This PR updates the peer dependencies to include support for NestJS 11.