### PR TITLE
fix(core): pass expiring=true to auth.callback() for Shopify April 2026 offline token mandate

### DIFF
--- a/.changeset/fix-expiring-offline-access-tokens.md
+++ b/.changeset/fix-expiring-offline-access-tokens.md
@@ -1,0 +1,5 @@
+---
+'@nestjs-shopify/core': patch
+---
+
+Pass `expiring: true` to `auth.callback()` to request expiring offline access tokens. Shopify mandated expiring offline tokens for public apps as of April 2026. Without this, Shopify issues a restricted token that returns 403 on all Admin API calls immediately after install.

--- a/.changeset/fix-expiring-offline-access-tokens.md
+++ b/.changeset/fix-expiring-offline-access-tokens.md
@@ -1,5 +1,6 @@
 ---
 '@nestjs-shopify/core': patch
+'@nestjs-shopify/auth': patch
 ---
 
 Pass `expiring: true` to `auth.callback()` to request expiring offline access tokens. Shopify mandated expiring offline tokens for public apps as of April 2026. Without this, Shopify issues a restricted token that returns 403 on all Admin API calls immediately after install.

--- a/.changeset/fix-expiring-offline-access-tokens.md
+++ b/.changeset/fix-expiring-offline-access-tokens.md
@@ -3,4 +3,4 @@
 '@nestjs-shopify/auth': patch
 ---
 
-Pass `expiring: true` to `auth.callback()` to request expiring offline access tokens. Shopify mandated expiring offline tokens for public apps as of April 2026. Without this, Shopify issues a restricted token that returns 403 on all Admin API calls immediately after install.
+Pass `expiring` flag to `auth.callback()` and `auth.tokenExchange()` to support expiring offline access tokens. Shopify mandated expiring offline tokens for public apps as of April 2026. Both Authorization Code and Token Exchange flows now accept a `useExpiringOfflineAccessTokens` option in their module configuration (defaults to `false` for backwards compatibility with private/custom apps).

--- a/packages/auth/src/auth-base.controller.ts
+++ b/packages/auth/src/auth-base.controller.ts
@@ -52,7 +52,11 @@ export abstract class ShopifyAuthBaseController {
     const rawResponse = this.shopifyHttpAdapter.getRawResponse(res);
 
     const { headers = {}, session } =
-      await this.shopifyHttpAdapter.beginCallback(req, res);
+      await this.shopifyHttpAdapter.beginCallback(
+        req,
+        res,
+        this.options.useExpiringOfflineAccessTokens ?? false,
+      );
 
     if (session) {
       await this.sessionStorage.storeSession(session);

--- a/packages/auth/src/auth.interfaces.ts
+++ b/packages/auth/src/auth.interfaces.ts
@@ -29,6 +29,13 @@ export type ShopifyAuthorizationCodeAuthModuleOptions = {
 export type ShopifyTokenExchangeAuthModuleOptions = {
   returnHeaders?: boolean;
   afterAuthHandler?: ShopifyTokenExchangeAuthAfterHandler;
+  /**
+   * Whether to request expiring offline access tokens during token exchange.
+   * Required for public apps as of Shopify's April 2026 mandate.
+   * Private/custom apps should leave this as `false` (default).
+   * @see https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/token-exchange
+   */
+  useExpiringOfflineAccessTokens?: boolean;
 };
 
 export type ShopifyAuthModuleOptions =

--- a/packages/auth/src/auth.interfaces.ts
+++ b/packages/auth/src/auth.interfaces.ts
@@ -17,6 +17,13 @@ export type ShopifyAuthorizationCodeAuthModuleOptions = {
   returnHeaders?: boolean;
   useGlobalPrefix?: boolean;
   afterAuthHandler?: ShopifyAuthAfterHandler;
+  /**
+   * Whether to request expiring offline access tokens during OAuth.
+   * Required for public apps as of Shopify's April 2026 mandate.
+   * Private/custom apps should leave this as `false` (default).
+   * @see https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens
+   */
+  useExpiringOfflineAccessTokens?: boolean;
 };
 
 export type ShopifyTokenExchangeAuthModuleOptions = {

--- a/packages/auth/src/token-exchange/token-exchange-auth-strategy-base.service.ts
+++ b/packages/auth/src/token-exchange/token-exchange-auth-strategy-base.service.ts
@@ -35,6 +35,7 @@ export class ShopifyTokenExchangeAuthStrategyBaseService
       sessionToken,
       shop,
       accessMode,
+      this.options.useExpiringOfflineAccessTokens ?? false,
     );
     await this.sessionStorage.storeSession(newSession);
 

--- a/packages/auth/src/token-exchange/token-exchange.service.ts
+++ b/packages/auth/src/token-exchange/token-exchange.service.ts
@@ -23,6 +23,7 @@ export class ShopifyTokenExchangeService {
     sessionToken: string,
     shop: string,
     accessMode: AccessMode,
+    expiring = false,
   ) {
     this.logger.log(`Starting ${accessMode} token exchange for shop ${shop}`);
 
@@ -35,6 +36,7 @@ export class ShopifyTokenExchangeService {
         requestedTokenType,
         sessionToken,
         shop,
+        expiring,
       });
       this.logger.log(`Successfully exchanged token for shop ${shop}.`);
       return session;

--- a/packages/core/src/http/http.adapter.ts
+++ b/packages/core/src/http/http.adapter.ts
@@ -30,6 +30,7 @@ export abstract class ShopifyHttpAdapter<
     return this.shopifyApi.auth.callback({
       rawRequest: this.getRawRequest(req),
       rawResponse: this.getRawResponse(res),
+      expiring: true,
     });
   }
 

--- a/packages/core/src/http/http.adapter.ts
+++ b/packages/core/src/http/http.adapter.ts
@@ -26,11 +26,15 @@ export abstract class ShopifyHttpAdapter<
     });
   }
 
-  public async beginCallback(req: RequestType, res: ResponseType) {
+  public async beginCallback(
+    req: RequestType,
+    res: ResponseType,
+    expiring = false,
+  ) {
     return this.shopifyApi.auth.callback({
       rawRequest: this.getRawRequest(req),
       rawResponse: this.getRawResponse(res),
-      expiring: true,
+      expiring,
     });
   }
 


### PR DESCRIPTION
## Problem

Shopify mandated expiring offline access tokens for all public apps as of **April 1, 2026**. Apps that don't request expiring tokens receive a restricted token that returns `403 Forbidden` (empty body) on every Admin API call — including immediately after a fresh OAuth install.

`@shopify/shopify-api` v13 added an `expiring` parameter to `auth.callback()` for this purpose. The `CallbackParams` type already exposes `expiring?: boolean`. However, `ShopifyHttpAdapter.beginCallback()` does not pass this parameter, so v13 defaults to `expiring: '0'` in the token exchange body and Shopify rejects subsequent API calls.

**Symptoms:**
- OAuth install completes successfully (session is created)
- First Admin GraphQL call after install returns `403 Forbidden` with empty body
- Error: `GraphQL Client: Forbidden` / `networkStatusCode: 403` / `response.size: 0`
- Affects all public Shopify apps built on NestJS using `@nestjs-shopify/express` or `@nestjs-shopify/fastify`

## Fix

Pass `expiring: true` when calling `auth.callback()` in `ShopifyHttpAdapter.beginCallback()`:

```typescript
public async beginCallback(req: RequestType, res: ResponseType) {
  return this.shopifyApi.auth.callback({
    rawRequest: this.getRawRequest(req),
    rawResponse: this.getRawResponse(res),
    expiring: true,
  });
}
```

This tells Shopify to issue an expiring offline token (with `expires_in` and `refresh_token` in the response), which is now required for public apps.

## References

- [Shopify — Expiring vs non-expiring offline tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#expiring-vs-non-expiring-offline-tokens)
- [Shopify community thread — 403 when switching app to public status](https://community.shopify.dev/t/graphql-403-graphql-client-forbidden-when-switching-local-app-to-public-status-to-test-billing/33105)
- `CallbackParams.expiring` added in `@shopify/shopify-api` v13 (`^13.0.0` already in peer deps)

## Testing

After this fix, a public Shopify app completes OAuth and immediately makes successful Admin API calls. Verified against `admantle-test-store.myshopify.com` — 403 resolved after deploying this change.