### PR TITLE
feat(auth): support expiring offline access tokens

### DIFF
--- a/.changeset/expiring-offline-access-tokens.md
+++ b/.changeset/expiring-offline-access-tokens.md
@@ -1,0 +1,10 @@
+---
+'@nestjs-shopify/auth': minor
+'@nestjs-shopify/core': minor
+---
+
+Add support for expiring offline access tokens via the new `useExpiringOfflineAccessTokens` option.
+
+Public apps must migrate to expiring offline access tokens by January 2027 (see [Shopify's migration guide](https://shopify.dev/docs/apps/build/authentication-authorization/migrate-to-expiring-offline-access-tokens)). When enabled, offline access tokens are requested with `expiring=1` in both the authorization code callback and token exchange flows.
+
+Note: this option requires `@shopify/shopify-api` >= 13.1.0. On older versions the flag is silently ignored.

--- a/integration/test/auth-e2e/fastify-hybrid-auth-flow.spec.ts
+++ b/integration/test/auth-e2e/fastify-hybrid-auth-flow.spec.ts
@@ -132,6 +132,7 @@ describe('Fastify: Hybrid Auth Flow (e2e)', () => {
       expect(callbackSpy).toHaveBeenCalledWith({
         rawRequest: expect.anything(),
         rawResponse: expect.anything(),
+        expiring: false,
       });
     });
 
@@ -223,6 +224,7 @@ describe('Fastify: Hybrid Auth Flow (e2e)', () => {
       expect(callbackSpy).toHaveBeenCalledWith({
         rawRequest: expect.anything(),
         rawResponse: expect.anything(),
+        expiring: false,
       });
     });
 

--- a/integration/test/auth-e2e/hybrid-auth-flow.spec.ts
+++ b/integration/test/auth-e2e/hybrid-auth-flow.spec.ts
@@ -116,6 +116,7 @@ describe('Hybrid Auth Flow (e2e)', () => {
       expect(callbackSpy).toHaveBeenCalledWith({
         rawRequest: expect.any(IncomingMessage),
         rawResponse: expect.any(ServerResponse),
+        expiring: false,
       });
     });
 
@@ -197,6 +198,7 @@ describe('Hybrid Auth Flow (e2e)', () => {
       expect(callbackSpy).toHaveBeenCalledWith({
         rawRequest: expect.any(IncomingMessage),
         rawResponse: expect.any(ServerResponse),
+        expiring: false,
       });
     });
 

--- a/integration/test/auth-e2e/token-exchange.spec.ts
+++ b/integration/test/auth-e2e/token-exchange.spec.ts
@@ -217,6 +217,7 @@ describe.each(testCases)(
           requestedTokenType: auth.tokenType,
           sessionToken: token,
           shop: TEST_SHOP,
+          ...(auth.type === 'offline' ? { expiring: false } : {}),
         });
 
         expect(sessionStorage.storeSession).toHaveBeenCalledWith(newSession);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12189,7 +12189,7 @@
     },
     "packages/auth": {
       "name": "@nestjs-shopify/auth",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dependencies": {
         "jose": "^5.9.6"
       },
@@ -12245,7 +12245,7 @@
     },
     "packages/core": {
       "name": "@nestjs-shopify/core",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
@@ -12313,7 +12313,7 @@
     },
     "packages/graphql": {
       "name": "@nestjs-shopify/graphql",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "peerDependencies": {
         "@nestjs-shopify/auth": "^6.0.0",
         "@nestjs-shopify/core": "^5.0.0",
@@ -12341,7 +12341,7 @@
     },
     "packages/webhooks": {
       "name": "@nestjs-shopify/webhooks",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "peerDependencies": {
         "@nestjs-shopify/common": "^2.0.0",
         "@nestjs-shopify/core": "^5.0.0",

--- a/packages/auth/src/auth-base.controller.ts
+++ b/packages/auth/src/auth-base.controller.ts
@@ -51,8 +51,16 @@ export abstract class ShopifyAuthBaseController {
     const rawRequest = this.shopifyHttpAdapter.getRawRequest(req);
     const rawResponse = this.shopifyHttpAdapter.getRawResponse(res);
 
+    const isOffline = this.accessMode === AccessMode.Offline;
+    const useExpiringOfflineAccessTokens =
+      isOffline && (this.options.useExpiringOfflineAccessTokens ?? false);
+
     const { headers = {}, session } =
-      await this.shopifyHttpAdapter.beginCallback(req, res);
+      await this.shopifyHttpAdapter.beginCallback(
+        req,
+        res,
+        useExpiringOfflineAccessTokens,
+      );
 
     if (session) {
       await this.sessionStorage.storeSession(session);

--- a/packages/auth/src/auth.interfaces.ts
+++ b/packages/auth/src/auth.interfaces.ts
@@ -17,11 +17,13 @@ export type ShopifyAuthorizationCodeAuthModuleOptions = {
   returnHeaders?: boolean;
   useGlobalPrefix?: boolean;
   afterAuthHandler?: ShopifyAuthAfterHandler;
+  useExpiringOfflineAccessTokens?: boolean;
 };
 
 export type ShopifyTokenExchangeAuthModuleOptions = {
   returnHeaders?: boolean;
   afterAuthHandler?: ShopifyTokenExchangeAuthAfterHandler;
+  useExpiringOfflineAccessTokens?: boolean;
 };
 
 export type ShopifyAuthModuleOptions =

--- a/packages/auth/src/token-exchange/token-exchange-auth-strategy-base.service.ts
+++ b/packages/auth/src/token-exchange/token-exchange-auth-strategy-base.service.ts
@@ -35,6 +35,7 @@ export class ShopifyTokenExchangeAuthStrategyBaseService
       sessionToken,
       shop,
       accessMode,
+      this.options.useExpiringOfflineAccessTokens ?? false,
     );
     await this.sessionStorage.storeSession(newSession);
 

--- a/packages/auth/src/token-exchange/token-exchange.service.ts
+++ b/packages/auth/src/token-exchange/token-exchange.service.ts
@@ -23,6 +23,7 @@ export class ShopifyTokenExchangeService {
     sessionToken: string,
     shop: string,
     accessMode: AccessMode,
+    expiring = false,
   ) {
     this.logger.log(`Starting ${accessMode} token exchange for shop ${shop}`);
 
@@ -35,6 +36,7 @@ export class ShopifyTokenExchangeService {
         requestedTokenType,
         sessionToken,
         shop,
+        ...(accessMode === AccessMode.Offline && { expiring }),
       });
       this.logger.log(`Successfully exchanged token for shop ${shop}.`);
       return session;

--- a/packages/auth/tests/unit/token-exchange.service.spec.ts
+++ b/packages/auth/tests/unit/token-exchange.service.spec.ts
@@ -1,0 +1,110 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import { RequestedTokenType, Session, Shopify } from '@shopify/shopify-api';
+import { AccessMode } from '../../src/auth.interfaces';
+import { ShopifyTokenExchangeService } from '../../src/token-exchange/token-exchange.service';
+
+const mockShopifyApi = {
+  auth: {
+    tokenExchange: jest.fn(),
+  },
+  config: { scopes: [] },
+} as unknown as Shopify;
+
+describe('ShopifyTokenExchangeService', () => {
+  let service: ShopifyTokenExchangeService;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new ShopifyTokenExchangeService(mockShopifyApi);
+  });
+
+  const mockSession = { shop: 'shop.myshopify.com' } as Session;
+
+  function mockSuccessfulExchange() {
+    (mockShopifyApi.auth.tokenExchange as jest.Mock).mockResolvedValue({
+      session: mockSession,
+    });
+  }
+
+  it('passes the expiring flag when exchanging offline tokens', async () => {
+    mockSuccessfulExchange();
+
+    await service.exchangeToken(
+      'session-token',
+      'shop.myshopify.com',
+      AccessMode.Offline,
+      true,
+    );
+
+    expect(mockShopifyApi.auth.tokenExchange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedTokenType: RequestedTokenType.OfflineAccessToken,
+        expiring: true,
+      }),
+    );
+  });
+
+  it('does not pass the expiring flag when exchanging online tokens', async () => {
+    mockSuccessfulExchange();
+
+    await service.exchangeToken(
+      'session-token',
+      'shop.myshopify.com',
+      AccessMode.Online,
+      true,
+    );
+
+    expect(mockShopifyApi.auth.tokenExchange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedTokenType: RequestedTokenType.OnlineAccessToken,
+      }),
+    );
+    expect(
+      (mockShopifyApi.auth.tokenExchange as jest.Mock).mock.calls[0][0],
+    ).not.toHaveProperty('expiring');
+  });
+
+  it('defaults to non-expiring offline tokens', async () => {
+    mockSuccessfulExchange();
+
+    await service.exchangeToken(
+      'session-token',
+      'shop.myshopify.com',
+      AccessMode.Offline,
+    );
+
+    expect(mockShopifyApi.auth.tokenExchange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedTokenType: RequestedTokenType.OfflineAccessToken,
+        expiring: false,
+      }),
+    );
+  });
+
+  it('returns the session from a successful exchange', async () => {
+    mockSuccessfulExchange();
+
+    const session = await service.exchangeToken(
+      'session-token',
+      'shop.myshopify.com',
+      AccessMode.Offline,
+      true,
+    );
+
+    expect(session).toBe(mockSession);
+  });
+
+  it('wraps unexpected errors in an internal server error exception', async () => {
+    (mockShopifyApi.auth.tokenExchange as jest.Mock).mockRejectedValue(
+      new Error('boom'),
+    );
+
+    await expect(
+      service.exchangeToken(
+        'session-token',
+        'shop.myshopify.com',
+        AccessMode.Offline,
+      ),
+    ).rejects.toThrow(InternalServerErrorException);
+  });
+});

--- a/packages/core/src/http/http.adapter.ts
+++ b/packages/core/src/http/http.adapter.ts
@@ -26,10 +26,15 @@ export abstract class ShopifyHttpAdapter<
     });
   }
 
-  public async beginCallback(req: RequestType, res: ResponseType) {
+  public async beginCallback(
+    req: RequestType,
+    res: ResponseType,
+    expiring = false,
+  ) {
     return this.shopifyApi.auth.callback({
       rawRequest: this.getRawRequest(req),
       rawResponse: this.getRawResponse(res),
+      expiring,
     });
   }
 

--- a/packages/core/tests/unit/http.adapter.spec.ts
+++ b/packages/core/tests/unit/http.adapter.spec.ts
@@ -1,0 +1,56 @@
+import { Shopify } from '@shopify/shopify-api';
+import { ShopifyHttpAdapter } from '../../src/http/http.adapter';
+
+const mockShopifyApi = {
+  auth: {
+    callback: jest.fn(),
+  },
+} as unknown as Shopify;
+
+class TestHttpAdapter extends ShopifyHttpAdapter<unknown, unknown> {
+  protected setHeader(): void {
+    // no-op: not used in these tests
+  }
+  protected extractHeaders() {
+    return {};
+  }
+  protected extractQueryParams<Query = Record<string, unknown>>(): Query {
+    return {} as Query;
+  }
+}
+
+describe('ShopifyHttpAdapter#beginCallback', () => {
+  let adapter: ShopifyHttpAdapter<unknown, unknown>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    adapter = new TestHttpAdapter(mockShopifyApi);
+  });
+
+  it.each([true, false])(
+    'passes the expiring flag (%p) to the OAuth callback',
+    async (expiring) => {
+      (mockShopifyApi.auth.callback as jest.Mock).mockResolvedValue({
+        session: undefined,
+      });
+
+      await adapter.beginCallback({}, {}, expiring);
+
+      expect(mockShopifyApi.auth.callback).toHaveBeenCalledWith(
+        expect.objectContaining({ expiring }),
+      );
+    },
+  );
+
+  it('defaults the expiring flag to false', async () => {
+    (mockShopifyApi.auth.callback as jest.Mock).mockResolvedValue({
+      session: undefined,
+    });
+
+    await adapter.beginCallback({}, {});
+
+    expect(mockShopifyApi.auth.callback).toHaveBeenCalledWith(
+      expect.objectContaining({ expiring: false }),
+    );
+  });
+});


### PR DESCRIPTION
> **Note:** Continues #604. The original author is no longer maintaining it.
> Credit to them for identifying the root cause.

## Problem

Shopify requires public apps to migrate to **expiring offline access tokens** by **January 2027**. `@shopify/shopify-api` supports this via an `expiring` param on `auth.callback()` and `auth.tokenExchange()`, but `@nestjs-shopify` never exposes it.

## Changes

- New **opt-in** option `useExpiringOfflineAccessTokens` on both auth module options
- Forward the flag to `auth.callback()` and `auth.tokenExchange()`
- Flag is sent only for offline flows (per Shopify docs, it doesn't apply to online tokens)
- Unit + integration tests, changeset

## Usage

```ts
// Authorization code flow
ShopifyAuthModule.forRootOffline({
  useExpiringOfflineAccessTokens: true,
});

// Token exchange flow (embedded apps)
ShopifyAuthModule.forRootOffline(
  AuthStrategy.TokenExchange,
  { useExpiringOfflineAccessTokens: true },
);

// Async (any strategy)
ShopifyAuthModule.forRootAsyncOffline(AuthStrategy.TokenExchange, {
  imports: [ConfigModule],
  useFactory: (config: ConfigService) => ({
    useExpiringOfflineAccessTokens: true,
  }),
  inject: [ConfigService],
});
```

## Compatibility

- Requires `@shopify/shopify-api` >= 13.1.0; older versions silently ignore the flag
- Default `false`, so existing apps are unaffected

## References

- [Shopify: Access tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens)
- [Migrate to expiring offline tokens](https://shopify.dev/docs/apps/build/authentication-authorization/migrate-to-expiring-offline-access-tokens)
- Continues #604